### PR TITLE
feat: add schema in memory

### DIFF
--- a/apps/docs/docs/client-sdk/api.md
+++ b/apps/docs/docs/client-sdk/api.md
@@ -36,6 +36,7 @@ constructor(options: GQLPTClientOptions)
 
 - `typeDefs`: string (optional) - GraphQL schema as a string
 - `url`: string (optional) - URL of a GraphQL endpoint
+- `schema`: GraphQLSchema (optional) - A GraphQL schema object
 - `headers`: Record string (optional) - Headers to send with GraphQL requests
 - `adapter`: Adapter - An instance of an AI adapter (e.g., AdapterOpenAI, AdapterAnthropic)
 

--- a/packages/gqlpt/tests/GQLPTClient.test.ts
+++ b/packages/gqlpt/tests/GQLPTClient.test.ts
@@ -39,10 +39,10 @@ adapters.forEach(({ name, adapter }) => {
       }).toThrow("Cannot parse typeDefs");
     });
 
-    test("should throw missing typeDefs or url", () => {
+    test("should throw Missing typeDefs, url or schema", () => {
       expect(() => {
         new GQLPTClient({ adapter });
-      }).toThrow("Missing typeDefs or url");
+      }).toThrow("Missing typeDefs, url or schema");
     });
 
     test("should connect to the server", async () => {

--- a/packages/gqlpt/tests/local-schema.test.ts
+++ b/packages/gqlpt/tests/local-schema.test.ts
@@ -1,0 +1,68 @@
+import { AdapterAnthropic } from "@gqlpt/adapter-anthropic";
+import { AdapterOpenAI } from "@gqlpt/adapter-openai";
+import { resolvers, schema, typeDefs } from "@gqlpt/utils";
+
+import { describe, test } from "@jest/globals";
+import dotenv from "dotenv";
+import {
+  buildSchema,
+  lexicographicSortSchema,
+  parse,
+  print,
+  printSchema,
+} from "graphql";
+
+import { GQLPTClient } from "../src";
+
+dotenv.config();
+
+const TEST_OPENAI_API_KEY = process.env.TEST_OPENAI_API_KEY as string;
+const TEST_ANTHROPIC_API_KEY = process.env.TEST_ANTHROPIC_API_KEY as string;
+
+const adapters = [
+  {
+    name: "OpenAI",
+    adapter: new AdapterOpenAI({ apiKey: TEST_OPENAI_API_KEY }),
+  },
+  {
+    name: "Anthropic",
+    adapter: new AdapterAnthropic({ apiKey: TEST_ANTHROPIC_API_KEY }),
+  },
+];
+
+adapters.forEach(({ name, adapter }) => {
+  describe(`Local Schema with ${name} Adapter`, () => {
+    test("should connect to the server", async () => {
+      const gqlpt = new GQLPTClient({
+        adapter,
+        schema,
+      });
+
+      await gqlpt.connect();
+
+      const generatedTypeDefs = gqlpt.getTypeDefs() as string;
+      const ast = buildSchema(typeDefs);
+      const sorted = lexicographicSortSchema(ast);
+
+      expect(print(parse(generatedTypeDefs))).toEqual(printSchema(sorted));
+    });
+
+    test("should generateAndSend with inline", async () => {
+      const gqlpt = new GQLPTClient({
+        adapter,
+        schema,
+      });
+
+      await gqlpt.connect();
+
+      const response = await gqlpt.generateAndSend("Find users by id 1");
+
+      expect(response).toEqual({
+        errors: undefined,
+        data: {
+          user: resolvers.Query.user(undefined, { id: "1" }),
+        },
+      });
+    });
+  });
+});

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,5 +1,5 @@
 export { introspection } from "./introspection";
-export { startServer, typeDefs, resolvers } from "./test-server";
+export { startServer, typeDefs, resolvers, schema } from "./test-server";
 export { postGeneratedQuery } from "./post-generated-query";
 export { compressTypeDefs } from "./compress-typedefs";
 export { hashTypeDefs } from "./hash-typedefs";

--- a/packages/utils/src/test-server.ts
+++ b/packages/utils/src/test-server.ts
@@ -24,7 +24,7 @@ export const resolvers = {
   },
 };
 
-const schema = makeExecutableSchema({
+export const schema = makeExecutableSchema({
   typeDefs,
   resolvers,
 });


### PR DESCRIPTION
Ability to use in-memory executable schema instead of typedefs or URLs. This bypasses the .generateAndSend method. If a schema is present, GQLPT will call it instead of the URL. 