### PR TITLE
feat: add query sort and required id

### DIFF
--- a/packages/cli/tests/__snapshots__/cli.test.ts.snap
+++ b/packages/cli/tests/__snapshots__/cli.test.ts.snap
@@ -20,7 +20,7 @@ exports[`generate should generate types and queries with openai adapter: Second 
 "{
   "39ee1aceb0ce9b806da116e1c7758115436d186ac73c0b343f516fa7ab947cdf": {
     "find posts by user id 2, return id and title, and body": {
-      "query": "query ($userId: ID!) {\\n  posts(userId: $userId) {\\n    id\\n    title\\n    body\\n  }\\n}",
+      "query": "query ($userId: ID!) {\\n  posts(userId: $userId) {\\n    body\\n    id\\n    title\\n  }\\n}",
       "variables": {
         "userId": "2"
       }

--- a/packages/gqlpt/package.json
+++ b/packages/gqlpt/package.json
@@ -38,11 +38,12 @@
     "graphql": "^16.0.0 || ^17.0.0"
   },
   "dependencies": {
+    "@apollo/utils.sortast": "^3.0.0",
     "@gqlpt/adapter-base": "workspace:^",
     "@gqlpt/utils": "workspace:^"
   },
   "devDependencies": {
-    "@gqlpt/adapter-openai": "workspace:^",
-    "@gqlpt/adapter-anthropic": "workspace:^"
+    "@gqlpt/adapter-anthropic": "workspace:^",
+    "@gqlpt/adapter-openai": "workspace:^"
   }
 }

--- a/packages/gqlpt/src/index.ts
+++ b/packages/gqlpt/src/index.ts
@@ -7,6 +7,7 @@ import {
   postGeneratedQuery,
 } from "@gqlpt/utils";
 
+import { sortAST } from "@apollo/utils.sortast";
 import { promises } from "fs";
 import {
   GraphQLSchema,
@@ -41,7 +42,7 @@ Rules for generating the GraphQL query:
    - Declare all GraphQL variables at the top of the query.
 
 2. Fields:
-   - Only include fields that are explicitly requested or necessary for the query.
+   - Only include fields that are explicitly requested or necessary for the query, however, if a 'id' field is available, it should be included.
    - For nested objects, only traverse if specifically asked or crucial for the query.
 
 3. Arguments and Input Types:
@@ -69,6 +70,7 @@ Rules for generating the GraphQL query:
 7. Always prefer input types when available:
 - Correct:   query($where: UserWhereInput) { users(where: $where) { id name } }
 - Incorrect: query($name: String) { users(where: { name: $name }) { id name } }
+- Ensure that if the input type is required in the schema, it is also required in the query.
 `;
 
 const TYPE_GENERATION_RULES = `
@@ -384,7 +386,8 @@ export class GQLPTClient<T extends MergedTypeMap = MergedTypeMap> {
 
     const queryAst = parse(result.query, { noLocation: true });
     const newAst = clearOperationNames(queryAst);
-    const printedQuery = print(newAst);
+    const sortedAst = sortAST(newAst);
+    const printedQuery = print(sortedAst);
 
     return {
       query: printedQuery,

--- a/packages/gqlpt/src/index.ts
+++ b/packages/gqlpt/src/index.ts
@@ -292,7 +292,8 @@ export class GQLPTClient<T extends MergedTypeMap = MergedTypeMap> {
     };
     const queryAst = parse(result.query, { noLocation: true });
     const newAst = clearOperationNames(queryAst);
-    const printedQuery = print(newAst);
+    const sortedAst = sortAST(newAst);
+    const printedQuery = print(sortedAst);
 
     return {
       query: printedQuery,

--- a/packages/gqlpt/tests/GQLPTClient.test.ts
+++ b/packages/gqlpt/tests/GQLPTClient.test.ts
@@ -3,22 +3,14 @@ import { AdapterOpenAI } from "@gqlpt/adapter-openai";
 
 import { describe, expect, test } from "@jest/globals";
 import dotenv from "dotenv";
-import { parse, print } from "graphql";
 
 import { GQLPTClient } from "../src";
+import { assertMatchesVariation, parsePrint } from "./utils";
 
 dotenv.config();
 
 const TEST_OPENAI_API_KEY = process.env.TEST_OPENAI_API_KEY as string;
 const TEST_ANTHROPIC_API_KEY = process.env.TEST_ANTHROPIC_API_KEY as string;
-
-function parsePrint(query: string) {
-  const parsed = parse(query, { noLocation: true });
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  parsed.definitions[0].name = undefined;
-  return print(parsed);
-}
 
 const adapters = [
   {
@@ -89,28 +81,31 @@ adapters.forEach(({ name, adapter }) => {
       const gqlpt = new GQLPTClient({ adapter, typeDefs });
 
       await gqlpt.connect();
-      const { query, variables } = await gqlpt.generateQueryAndVariables(
+      const result = await gqlpt.generateQueryAndVariables(
         "find users and their posts where name is dan, inject args into an object",
       );
 
-      expect(parsePrint(query)).toEqual(
-        parsePrint(`
-          query ($where: UserWhereInput) {
-            users(where: $where) {
-              id
-              name
-              email
-              posts {
+      assertMatchesVariation(result, [
+        {
+          query: `
+            query ($where: UserWhereInput) {
+              users(where: $where) {
                 id
-                title
-                body
+                name
+                email
+                posts {
+                  id
+                  title
+                  body
+                }
               }
             }
-          }
-        `),
-      );
-
-      expect(variables).toMatchObject({});
+          `,
+          variables: {
+            where: { name: "dan" },
+          },
+        },
+      ]);
     });
 
     test("should generate mutation", async () => {
@@ -121,9 +116,13 @@ adapters.forEach(({ name, adapter }) => {
           email: String!
         }
         
+        input FriendInput {
+          name: String!
+        }
+
         input CreateUserInput {
           name: String!
-          friends: [CreateUserInput]
+          friends: [FriendInput!]
         }
 
         type CreateUserResponse {
@@ -132,23 +131,73 @@ adapters.forEach(({ name, adapter }) => {
         }
 
         type Mutation {
-          createUser(input: CreateUserInput): [User!]!
+          createUser(input: CreateUserInput!): [User!]!
         }
       `;
 
       const gqlpt = new GQLPTClient({ adapter, typeDefs });
 
       await gqlpt.connect();
-      const { variables } = await gqlpt.generateQueryAndVariables(
+      const result = await gqlpt.generateQueryAndVariables(
         "create user with name dan and his friends bob and alice",
       );
 
-      expect(variables).toMatchObject({
-        input: {
-          name: "dan",
-          friends: [{ name: "bob" }, { name: "alice" }],
+      assertMatchesVariation(result, [
+        {
+          query: `
+            mutation ($input: CreateUserInput!) {
+              createUser(input: $input) {
+                id
+                name
+                email
+              }
+            }
+          `,
+          variables: {
+            input: {
+              name: "dan",
+              friends: [{ name: "bob" }, { name: "alice" }],
+            },
+          },
         },
-      });
+      ]);
+    });
+
+    test("should return fields in alphabetical order", async () => {
+      const typeDefs = `
+        type User {
+          zebra: String!
+          apple: String!
+          monkey: String!
+          banana: String!
+          cat: String!
+        }
+        
+        type Query {
+          user: User!
+        }
+      `;
+
+      const gqlpt = new GQLPTClient({ adapter, typeDefs });
+
+      await gqlpt.connect();
+      const { query } = await gqlpt.generateQueryAndTypeForBuild(
+        "get all user fields",
+      );
+
+      expect(parsePrint(query)).toBe(
+        parsePrint(`
+          query {
+            user {
+              apple
+              banana
+              cat
+              monkey
+              zebra
+            }
+          }
+        `),
+      );
     });
   });
 });

--- a/packages/gqlpt/tests/GQLPTClient.test.ts
+++ b/packages/gqlpt/tests/GQLPTClient.test.ts
@@ -90,13 +90,13 @@ adapters.forEach(({ name, adapter }) => {
           query: `
             query ($where: UserWhereInput) {
               users(where: $where) {
+                email
                 id
                 name
-                email
                 posts {
+                  body
                   id
                   title
-                  body
                 }
               }
             }
@@ -147,9 +147,9 @@ adapters.forEach(({ name, adapter }) => {
           query: `
             mutation ($input: CreateUserInput!) {
               createUser(input: $input) {
+                email
                 id
                 name
-                email
               }
             }
           `,

--- a/packages/gqlpt/tests/utils.ts
+++ b/packages/gqlpt/tests/utils.ts
@@ -1,0 +1,48 @@
+import { parse, print } from "graphql";
+
+export type QueryVariation = {
+  query: string;
+  variables?: Record<string, any>;
+};
+
+export type QueryResult = {
+  query: string;
+  variables?: Record<string, unknown>;
+};
+
+export function parsePrint(query: string) {
+  const parsed = parse(query, { noLocation: true });
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  parsed.definitions[0].name = undefined;
+  return print(parsed);
+}
+
+export function assertMatchesVariation(
+  actual: QueryResult,
+  expectedVariations: QueryVariation[],
+) {
+  const normalizedActual = {
+    query: parsePrint(actual.query),
+    variables: actual.variables || {},
+  };
+
+  const normalizedExpected = expectedVariations.map((variation) => ({
+    query: parsePrint(variation.query),
+    variables: variation.variables || {},
+  }));
+
+  const matches = normalizedExpected.some(
+    (expected) =>
+      expected.query === normalizedActual.query &&
+      JSON.stringify(expected.variables) ===
+        JSON.stringify(normalizedActual.variables),
+  );
+
+  if (!matches) {
+    throw new Error(
+      `Response does not match any expected variations.\n\nActual:\n${JSON.stringify(normalizedActual, null, 2)}\n\nExpected one of:\n${normalizedExpected.map((e) => JSON.stringify(e, null, 2)).join("\n\n")}`,
+    );
+  }
+  return true;
+}

--- a/packages/utils/src/test-server.ts
+++ b/packages/utils/src/test-server.ts
@@ -41,7 +41,6 @@ export function startServer({ port }: { port: number }): Promise<Server> {
     });
 
     server.listen(port, () => {
-      console.log(`Server listening on port ${port}`);
       resolve(server);
     });
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,6 +285,9 @@ importers:
 
   packages/gqlpt:
     dependencies:
+      '@apollo/utils.sortast':
+        specifier: ^3.0.0
+        version: 3.0.0(graphql@16.9.0)
       '@gqlpt/adapter-base':
         specifier: workspace:^
         version: link:../adapter-base
@@ -459,6 +462,12 @@ packages:
 
   '@anthropic-ai/sdk@0.27.1':
     resolution: {integrity: sha512-AKFd/E8HO26+DOVPiZpEked3Pm2feA5d4gcX2FcJXr9veDkXbKO90hr2C7N2TL7mPIMwm040ldXlsIZQ416dHg==}
+
+  '@apollo/utils.sortast@3.0.0':
+    resolution: {integrity: sha512-qZG5L95wnvYD8Nsh+kKvtTDomn76wOC8H1KJGsxMTifXyY5M+PdKeAJVfPkyw11Pkq7sGVg96vk2BZ6pdFP/QA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      graphql: 14.x || 15.x || 16.x
 
   '@babel/code-frame@7.26.2':
     resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
@@ -4672,6 +4681,9 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  lodash.sortby@4.7.0:
+    resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
+
   lodash.uniq@4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
 
@@ -7265,6 +7277,11 @@ snapshots:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
+
+  '@apollo/utils.sortast@3.0.0(graphql@16.9.0)':
+    dependencies:
+      graphql: 16.9.0
+      lodash.sortby: 4.7.0
 
   '@babel/code-frame@7.26.2':
     dependencies:
@@ -13028,6 +13045,8 @@ snapshots:
   lodash.memoize@4.1.2: {}
 
   lodash.merge@4.6.2: {}
+
+  lodash.sortby@4.7.0: {}
 
   lodash.uniq@4.5.0: {}
 


### PR DESCRIPTION
This PR adds https://www.npmjs.com/package/@apollo/utils.sortast so that the generated query is more deterministic. It also adds a clause to the prompt to ensure that ids are always selected if present. 